### PR TITLE
Install Rust toolchain to use Rust's package manager `cargo`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,10 @@ RUN sudo apt-get autoremove -y \
   && sudo apt-get clean \
   && sudo rm -rf /home/lichess/build
 
+# Install Rust toolchain to use `cargo`
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+RUN echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
+
 ADD run.sh /home/lichess/run.sh
 
 # Use UTF-8 encoding.


### PR DESCRIPTION
This PR is for the last change (for now) to the `lichess-docker` side of things. It makes `cargo` available for use in the Docker container, which is necessary to run fishnet.

For reference, the other changes made to `lichess-docker` as part of the effort to streamline setup for now were:
- Changing `readlink` to `greadlink` (available on Macs with `brew install coreutils`)
- Changing the Docker run script so that we bind mount the entirety of `lichess-dev` in the Docker container, rather than just the submodules inside `lichess-dev/lichess-server`. This resolves the issue of the submodules not being valid git repositories. The previous workaround was manually re-cloning each repo once inside the Docker container.